### PR TITLE
chore: improve deployment and ci

### DIFF
--- a/.github/workflows/exporter.yaml
+++ b/.github/workflows/exporter.yaml
@@ -21,9 +21,9 @@ jobs:
       postgres:
         image: postgres:14
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: postgres
+          POSTGRES_USER: ${{ secrets.CI_DATABASE_USERNAME }}
+          POSTGRES_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.CI_DATABASE_NAME }}
         ports:
           - 5432:5432
     steps:
@@ -103,7 +103,7 @@ jobs:
         uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: ${{ secrets.GCP_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_IAM_EMAIL }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
@@ -136,7 +136,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ${{ secrets.CLOUD_RUN_IMAGE_EXPORTER }}
+            ${{ secrets.CLOUD_RUN_EXPORTER_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
@@ -162,3 +162,20 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache
           mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+      
+      - name: Update Cloud Run Job
+        run: |
+          gcloud beta run jobs update ${{ secrets.CLOUD_RUN_EXPORTER }} \
+          --project=${{ secrets.GCP_PROJECT_ID }} \
+          --image=${{ secrets.CLOUD_RUN_EXPORTER_IMAGE }}:${{ steps.tag.outputs.sha }} \
+          --service-account=${{ secrets.CLOUD_RUN_SERVICE_ACCOUNT }} \
+          --parallelism=1 \
+          --set-cloudsql-instances=${{ secrets.CLOUD_SQL_DB }} \
+          --execution-environment=gen2 \
+          --region=us-central1 \
+          --set-env-vars=EXPORTER__DATABASE__REQUIRE_SSL=false \
+          --set-secrets=EXPORTER__DATABASE__SOCKET=APP__DATABASE__SOCKET:2 \
+          --set-secrets=EXPORTER__DATABASE__DATABASE_NAME=APP__DATABASE__DATABASE_NAME:1 \
+          --set-secrets=EXPORTER__DATABASE__PASSWORD=APP__DATABASE__PASSWORD:1 \
+          --set-secrets=EXPORTER__DATABASE__USERNAME=APP__DATABASE__USERNAME:1 \
+          --set-secrets=EXPORTER__SHEETS__SPREADSHEET_ID=EXPORTER__SHEETS__SPREADSHEET_ID:1

--- a/.github/workflows/exporter.yaml
+++ b/.github/workflows/exporter.yaml
@@ -12,6 +12,10 @@ env:
   CARGO_TERM_COLOR: always
   SQLX_VERSION: 0.6.1
   SQLX_FEATURES: postgres,rustls
+  POSTGRES_USER: ${{ secrets.CI_DATABASE_USERNAME }}
+  POSTGRES_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
+  POSTGRES_DB: ${{ secrets.CI_DATABASE_NAME }}
+  POSTGRES_HOST: localhost
 
 jobs:
   fmt-lint-test:
@@ -29,7 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - run: cp .env-example .env
+      - name: Setup .env
+        run: ./scripts/create_env.sh
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -21,9 +21,9 @@ jobs:
       postgres:
         image: postgres:14
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: postgres
+          POSTGRES_USER: ${{ secrets.CI_DATABASE_USERNAME }}
+          POSTGRES_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.CI_DATABASE_NAME }}
         ports:
           - 5432:5432
     steps:
@@ -96,7 +96,7 @@ jobs:
         uses: google-github-actions/auth@v0
         with:
           workload_identity_provider: ${{ secrets.GCP_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_IAM_EMAIL }}
+          service_account: ${{ secrets.GCP_DEPLOY_SERVICE_ACCOUNT }}
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v0
@@ -129,7 +129,7 @@ jobs:
         uses: docker/metadata-action@v3
         with:
           images: |
-            ${{ secrets.CLOUD_RUN_IMAGE }}
+            ${{ secrets.CLOUD_RUN_APP_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
@@ -160,7 +160,7 @@ jobs:
         run: |
           gcloud beta run deploy ${{ secrets.CLOUD_RUN_APP }} \
           --project=${{ secrets.GCP_PROJECT_ID }} \
-          --image=${{ secrets.CLOUD_RUN_IMAGE }}:${{ steps.tag.outputs.sha }} \
+          --image=${{ secrets.CLOUD_RUN_APP_IMAGE }}:${{ steps.tag.outputs.sha }} \
           --service-account=${{ secrets.CLOUD_RUN_SERVICE_ACCOUNT }} \
           --port=${{ secrets.APP__APPLICATION__PORT }} \
           --set-cloudsql-instances=${{ secrets.CLOUD_SQL_DB }} \
@@ -190,14 +190,12 @@ jobs:
       postgres:
         image: postgres:14
         env:
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: password
-          POSTGRES_DB: postgres
+          POSTGRES_USER: ${{ secrets.CI_DATABASE_USERNAME }}
+          POSTGRES_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
+          POSTGRES_DB: ${{ secrets.CI_DATABASE_NAME }}
         ports:
           - 5432:5432
     if: ${{ contains(github.ref, 'dependabot') == false }}
-    env:
-      DATABASE_URL: postgres://postgres:password@localhost:5432/swu
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2

--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -12,6 +12,10 @@ env:
   CARGO_TERM_COLOR: always
   SQLX_VERSION: 0.6.1
   SQLX_FEATURES: postgres,rustls
+  POSTGRES_USER: ${{ secrets.CI_DATABASE_USERNAME }}
+  POSTGRES_PASSWORD: ${{ secrets.CI_DATABASE_PASSWORD }}
+  POSTGRES_DB: ${{ secrets.CI_DATABASE_NAME }}
+  POSTGRES_HOST: localhost
 
 jobs:
   fmt-lint-test:
@@ -29,7 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - run: cp .env-example .env
+      - name: Setup .env
+        run: ./scripts/create_env.sh
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
@@ -199,7 +204,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-      - run: cp .env-example .env
+      - name: Setup .env
+        run: ./scripts/create_env.sh
 
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+ignore:
+  - "apps/exporter"

--- a/scripts/create_env.sh
+++ b/scripts/create_env.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -e
+shopt -s expand_aliases
+
+if ! [ -x "$(command -v gsed)" ]; then
+    alias sed_cmd="sed"
+else
+    alias sed_cmd="gsed"
+fi
+
+FILE=.env
+if [[ -f "$FILE" ]]; then
+    echo "$FILE exists already - exiting"
+    exit 0
+fi
+
+if [[ -z $POSTGRES_DB || -z $POSTGRES_HOST || -z $POSTGRES_PASSWORD || -z $POSTGRES_USER ]]; then
+    >&2 echo "Please define following env variables POSTGRES_DB, POSTGRES_USER, POSTGRES_HOST, POSTGRES_PASSWORD"
+    exit 999
+fi
+
+cp .env-example $FILE
+
+sed_cmd -i "s/\"postgres\"/\"${POSTGRES_USER}\"/g" $FILE
+sed_cmd -i "s/\"password\"/\"${POSTGRES_PASSWORD}\"/g" $FILE
+sed_cmd -i "s/postgres\:password/${POSTGRES_USER}\:${POSTGRES_PASSWORD}/g" $FILE
+sed_cmd -i "s/localhost/${POSTGRES_HOST}/g" $FILE
+sed_cmd -i "s/swu/${POSTGRES_DB}/g" $FILE


### PR DESCRIPTION
## What?

- create a script that can generate .env
- improve init_db script so that it doesn't just wait for ever and will fail after 10 seconds
- inject postgres credentials for CI/CD

## Why?

Current setup assumes the CI/CD database creds are the postgres/password default stuff.
This broke on the automatically created PRs from dependabot.
And the init_db script just kept trying to connect - ended up having actions run for over an hour.

## Testing/Proof

Success of the github actions for this PR