### PR TITLE
fix: add /dashboard to login redirect to support landing page on /

### DIFF
--- a/apps/server/src/routes/bigcommerce.rs
+++ b/apps/server/src/routes/bigcommerce.rs
@@ -87,7 +87,7 @@ async fn install(
         .append_header((
             LOCATION,
             format!(
-                "{}/?token={}&store-id={}",
+                "{}/dashboard/?token={}&store-id={}",
                 base_url.get_ref(),
                 &jwt,
                 store.get_store_hash()
@@ -149,7 +149,7 @@ async fn load(
         .append_header((
             LOCATION,
             format!(
-                "{}/?token={}&store-id={}",
+                "{}/dashboard/?token={}&store-id={}",
                 base_url.get_ref(),
                 &jwt,
                 &store_hash


### PR DESCRIPTION
## What?

Add `/dashboard` to the login redirect

## Why?

Currently we automatically serve dashboard index.html on both `/` and `/dashboard`, but since we are adding landing page we should redirect to the direct route so that `/` can serve landing page.

## Testing/Proof

N/A