### PR TITLE
fix: separate the bigcommerce oauth redirect from base_url

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -2,14 +2,14 @@ DATABASE_URL = "postgres://postgres:password@localhost:5432/swu"
 APP__DATABASE__USERNAME = "postgres"
 APP__DATABASE__PASSWORD = "password"
 APP__DATABASE__DATABASE_NAME = "swu"
-APP__DATABASE__REQUIRE_SSL = false
+APP__DATABASE__REQUIRE_SSL = "false"
 APP__DATABASE__HOST = "localhost"
 APP__DATABASE__PORT = 5432
 
 EXPORTER__DATABASE__USERNAME = "postgres"
 EXPORTER__DATABASE__PASSWORD = "password"
 EXPORTER__DATABASE__DATABASE_NAME = "swu"
-EXPORTER__DATABASE__REQUIRE_SSL = false
+EXPORTER__DATABASE__REQUIRE_SSL = "false"
 EXPORTER__DATABASE__HOST = "localhost"
 EXPORTER__DATABASE__PORT = 5432
 
@@ -22,9 +22,10 @@ APP__BIGCOMMERCE__LOGIN_BASE_URL = "https://login.bigcommerce.com"
 APP__BIGCOMMERCE__TIMEOUT = 10000
 APP__BIGCOMMERCE__CLIENT_ID = ""
 APP__BIGCOMMERCE__CLIENT_SECRET = ""
+APP__BIGCOMMERCE__INSTALL_REDIRECT_URI = "https://stand-with-ukraine-bc-app.web.app/bigcommerce/install"
 
 APP__APPLICATION__PORT = 8000
-APP__APPLICATION__BASE_URL = "https://stand-with-ukraine-bc-app.web.app"
+APP__APPLICATION__BASE_URL = "https://standwithukraineapp.com"
 APP__APPLICATION__LIGHTSTEP_ACCESS_TOKEN = ""
 APP__APPLICATION__JWT_SECRET = "app-app-jwt-secret"
 APP__APPLICATION__HOST = "0.0.0.0"

--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -178,6 +178,7 @@ jobs:
           --region=us-central1 \
           --set-env-vars=APP__APPLICATION__PORT=${{ secrets.APP__APPLICATION__PORT }} \
           --set-env-vars=APP__APPLICATION__BASE_URL=${{ secrets.APP__APPLICATION__BASE_URL }} \
+          --set-env-vars=APP__BIGCOMMERCE__INSTALL_REDIRECT_URI=${{ secrets.APP__BIGCOMMERCE__INSTALL_REDIRECT_URI }} \
           --set-env-vars=APP__DATABASE__REQUIRE_SSL=false \
           --set-secrets=APP__DATABASE__SOCKET=APP__DATABASE__SOCKET:2 \
           --set-secrets=APP__DATABASE__DATABASE_NAME=APP__DATABASE__DATABASE_NAME:1 \

--- a/apps/server/configuration/base.yaml
+++ b/apps/server/configuration/base.yaml
@@ -17,3 +17,4 @@ bigcommerce:
   timeout: 10000
   client_secret: ""
   client_id: ""
+  install_redirect_uri: http://localhost:8000/bigcommerce/install

--- a/apps/server/src/configuration.rs
+++ b/apps/server/src/configuration.rs
@@ -31,6 +31,7 @@ pub struct Database {
 pub struct BigCommerce {
     pub client_id: String,
     pub client_secret: Secret<String>,
+    pub install_redirect_uri: String,
 
     pub api_base_url: String,
     pub login_base_url: String,

--- a/apps/server/src/startup.rs
+++ b/apps/server/src/startup.rs
@@ -24,6 +24,7 @@ impl Application {
             configuration.bigcommerce.login_base_url,
             configuration.bigcommerce.client_id,
             configuration.bigcommerce.client_secret,
+            configuration.bigcommerce.install_redirect_uri,
             std::time::Duration::from_millis(configuration.bigcommerce.timeout.into()),
         );
 


### PR DESCRIPTION
## What?

Separate the api oauth redirect_uri from server base_url in configuration to allow flexibility

## Why?

The current bigcommerce marketplace setting and base_url for the app have diverged, and this allows us to fix it without having to change the app configuration in the BigCommerce app store.

## Testing/Proof

N/A