### PR TITLE
feature: add support for universal widget events

### DIFF
--- a/.rusty-hook.toml
+++ b/.rusty-hook.toml
@@ -1,0 +1,6 @@
+[hooks]
+pre-commit = "./scripts/pre_commit.sh"
+pre-push = "./scripts/pre_push.sh"
+
+[logging]
+verbose = true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "ci_info"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24f638c70e8c5753795cc9a8c07c44da91554a09e4cf11a7326e8161b0a3c45e"
+dependencies = [
+ "envmnt",
+]
+
+[[package]]
 name = "concurrent-queue"
 version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -659,6 +668,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "envmnt"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d328fc287c61314c4a61af7cfdcbd7e678e39778488c7cb13ec133ce0f4059"
+dependencies = [
+ "fsio",
+ "indexmap",
+]
+
+[[package]]
 name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,6 +716,12 @@ checksum = "a9c384f161156f5260c24a097c56119f9be8c798586aecc13afbcbe7b7e26bf8"
 dependencies = [
  "percent-encoding 2.2.0",
 ]
+
+[[package]]
+name = "fsio"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1fd087255f739f4f1aeea69f11b72f8080e9c2e7645cd06955dad4a178a49e3"
 
 [[package]]
 name = "futures"
@@ -837,6 +862,15 @@ checksum = "c1ebd34e35c46e00bb73e81363248d627782724609fe1b6396f553f68fe3862e"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -1311,6 +1345,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.36.1",
 ]
+
+[[package]]
+name = "nias"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab250442c86f1850815b5d268639dff018c0627022bc1940eb2d642ca1ce12f0"
 
 [[package]]
 name = "nom"
@@ -1955,6 +1995,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusty-hook"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96cee9be61be7e1cbadd851e58ed7449c29c620f00b23df937cb9cbc04ac21a3"
+dependencies = [
+ "ci_info",
+ "getopts",
+ "nias",
+ "toml",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2322,6 +2374,7 @@ dependencies = [
  "opentelemetry-jaeger",
  "reqwest",
  "rstest",
+ "rusty-hook",
  "secrecy",
  "serde",
  "serde-aux",
@@ -2349,6 +2402,7 @@ dependencies = [
  "google-sheets4",
  "rand 0.8.5",
  "rstest",
+ "rusty-hook",
  "serde",
  "serde_json",
  "sqlx",
@@ -2686,6 +2740,12 @@ name = "unicode-segmentation"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fdbf052a0783de01e944a6ce7a8cb939e295b1e7be835a1112c3b9a7f047a5a"
+
+[[package]]
+name = "unicode-width"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0edd1e5b14653f783770bce4a4dabb4a5108a5370a5f5d8cfe8710c361f6c8b"
 
 [[package]]
 name = "unicode_categories"

--- a/apps/exporter/Cargo.toml
+++ b/apps/exporter/Cargo.toml
@@ -37,3 +37,4 @@ features = [
 [dev-dependencies]
 rstest = "0.16.0"
 rand = "0.8.5"
+rusty-hook = "^0.11.2"

--- a/apps/server/Cargo.toml
+++ b/apps/server/Cargo.toml
@@ -67,3 +67,4 @@ features = ["macros", "rt-multi-thread"]
 [dev-dependencies]
 rstest = "0.16.0"
 wiremock = "0.5.17"
+rusty-hook = "^0.11.2"

--- a/apps/server/sqlx-data.json
+++ b/apps/server/sqlx-data.json
@@ -98,6 +98,20 @@
     },
     "query": "\n        INSERT INTO widget_events (store_hash, event_type, created_at)\n        VALUES ($1, $2, $3);\n        "
   },
+  "6d4f9de8180dccaa71801dd55e01e029d6e3b53e175d98948e8f292afce6ec15": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Timestamptz",
+          "Varchar",
+          "Varchar"
+        ]
+      }
+    },
+    "query": "\n        INSERT INTO universal_installer_events (submitted_at, event_type, metadata)\n        VALUES ($1, $2, $3);\n        "
+  },
   "82f438f197114b0bf39ff73fa6e43b2737f111551396ffd53610786519796279": {
     "describe": {
       "columns": [],

--- a/apps/server/tests/e2e/helpers.rs
+++ b/apps/server/tests/e2e/helpers.rs
@@ -167,6 +167,15 @@ impl TestApp {
         .map(|row| row.event_type)
     }
 
+    pub async fn get_universal_widget_events(&self) -> impl Iterator<Item = String> {
+        sqlx::query!("SELECT event_type FROM widget_events WHERE store_hash IS NULL")
+            .fetch_all(&self.db_pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| row.event_type)
+    }
+
     pub async fn get_form_feedback_submissions(
         &self,
     ) -> impl Iterator<Item = (String, String, String)> {
@@ -176,6 +185,17 @@ impl TestApp {
             .unwrap()
             .into_iter()
             .map(|row| (row.name, row.email, row.message))
+    }
+
+    pub async fn get_universal_configurator_submissions(
+        &self,
+    ) -> impl Iterator<Item = (String, Option<String>)> {
+        sqlx::query!("SELECT event_type, metadata FROM universal_installer_events;")
+            .fetch_all(&self.db_pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| (row.event_type, row.metadata))
     }
 
     pub async fn get_charity_visited_events(
@@ -191,6 +211,17 @@ impl TestApp {
         .unwrap()
         .into_iter()
         .map(|row| (row.charity, row.event_type))
+    }
+
+    pub async fn get_universal_charity_visited_events(
+        &self,
+    ) -> impl Iterator<Item = (String, String)> {
+        sqlx::query!("SELECT charity, event_type FROM charity_events WHERE store_hash IS NULL;")
+            .fetch_all(&self.db_pool)
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|row| (row.charity, row.event_type))
     }
 }
 

--- a/migrations/20230216161815_track_universal_installs_and_events.sql
+++ b/migrations/20230216161815_track_universal_installs_and_events.sql
@@ -1,0 +1,13 @@
+-- Add universal analytics tables
+CREATE TABLE universal_installer_events(
+	id bigserial PRIMARY KEY,
+	submitted_at timestamptz NOT NULL,
+    event_type VARCHAR(50) NOT NULL,
+	metadata VARCHAR(100)
+);
+
+ALTER TABLE charity_events
+ALTER COLUMN store_hash DROP NOT NULL;
+
+ALTER TABLE widget_events
+ALTER COLUMN store_hash DROP NOT NULL;


### PR DESCRIPTION
## What?

Add support for universal widget and charity events
Add tracking for universal configurator widget events

## Why?

Our widget and charity events used to track to store_hash and now we are allowing null to track events for widgets that are not tied to universal widgets not tied to bigcommerce store hashes.

## Testing/Proof

N/A