### PR TITLE
fix: improve configuration loading

### DIFF
--- a/apps/server/src/configuration.rs
+++ b/apps/server/src/configuration.rs
@@ -76,6 +76,9 @@ pub struct Application {
     pub port: u16,
 }
 
+const CONFIGURATION_PATH: &str = "configuration/base";
+const SERVER_WORKSPACE_PATH: &str = "apps/server";
+
 impl Configuration {
     /// # Errors
     ///
@@ -85,10 +88,17 @@ impl Configuration {
 
         let base_path =
             std::env::current_dir().expect("Failed to determine the current directory.");
-        let configuration_directory = base_path.join("configuration");
 
         Config::builder()
-            .add_source(File::from(configuration_directory.join("base")).required(true))
+            .add_source(File::from(base_path.join(CONFIGURATION_PATH)).required(false))
+            .add_source(
+                File::from(
+                    base_path
+                        .join(SERVER_WORKSPACE_PATH)
+                        .join(CONFIGURATION_PATH),
+                )
+                .required(false),
+            )
             .add_source(Environment::with_prefix("APP").separator("__"))
             .build()?
             .try_deserialize()


### PR DESCRIPTION
## What?

Try to load configuration from both cwd and the nested `apps/server` location and make them not required to support using ENV variables exclusively

## Why?

Make it easier for new team members to run the project.

## Testing/Proof

<img width="1624" alt="Screenshot 2024-02-21 at 11 53 11 AM" src="https://github.com/bigcommerce/stand-with-ukraine-backend/assets/95306190/30ef5972-ac99-4360-b750-c076447d73a4">