### PR TITLE
feature: enable production otel

### DIFF
--- a/.github/workflows/server.yaml
+++ b/.github/workflows/server.yaml
@@ -124,11 +124,21 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Docker Image Metadata
-        id: meta
+        id: backend-meta
         uses: docker/metadata-action@v4
         with:
           images: |
             ${{ secrets.CLOUD_RUN_APP_IMAGE }}
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+
+      - name: Docker Image Metadata
+        id: otel-collector-meta
+        uses: docker/metadata-action@v4
+        with:
+          images: |
+            ${{ secrets.CLOUD_RUN_OTEL_COLLECTOR_IMAGE }}
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
             type=sha
@@ -148,38 +158,36 @@ jobs:
           file: apps/server/Dockerfile
           target: runtime
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.backend-meta.outputs.tags }}
+          labels: ${{ steps.backend-meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Build collector image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          provenance: false
+          file: otel-collector/Dockerfile
+          target: runtime
+          push: true
+          tags: ${{ steps.otel-collector-meta.outputs.tags }}
+          labels: ${{ steps.otel-collector-meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Replace variables in run-service.yaml
+        run: |
+          sed -i s@%OTEL_COLLECTOR_IMAGE%@${{ fromJSON(steps.otel-collector-meta.outputs.json).tags[1] }}@g run-service.yaml
+          sed -i s@%APP_IMAGE%@${{ fromJSON(steps.backend-meta.outputs.json).tags[1] }}@g run-service.yaml
+          sed -i s@%SERVICE_ACCOUNT%@${{ secrets.CLOUD_RUN_SERVICE_ACCOUNT }}@g run-service.yaml
+          sed -i s@%APP__APPLICATION__PORT%@${{ secrets.APP__APPLICATION__PORT }}@g run-service.yaml
+          sed -i s@%APP__APPLICATION__BASE_URL%@${{ secrets.APP__APPLICATION__BASE_URL }}@g run-service.yaml
+          sed -i s@%APP__BIGCOMMERCE__INSTALL_REDIRECT_URI%@${{ secrets.APP__BIGCOMMERCE__INSTALL_REDIRECT_URI }}@g run-service.yaml
+
       - name: Deploy Cloud Run
         run: |
-          gcloud beta run deploy ${{ secrets.CLOUD_RUN_APP }} \
-          --project=${{ secrets.GCP_PROJECT_ID }} \
-          --image=${{ fromJSON(steps.meta.outputs.json).tags[1] }} \
-          --service-account=${{ secrets.CLOUD_RUN_SERVICE_ACCOUNT }} \
-          --port=${{ secrets.APP__APPLICATION__PORT }} \
-          --set-cloudsql-instances=${{ secrets.CLOUD_SQL_DB }} \
-          --allow-unauthenticated \
-          --concurrency=1000 \
-          --min-instances=1 \
-          --max-instances=5 \
-          --execution-environment=gen2 \
-          --region=us-central1 \
-          --set-env-vars=APP__APPLICATION__PORT=${{ secrets.APP__APPLICATION__PORT }} \
-          --set-env-vars=APP__APPLICATION__BASE_URL=${{ secrets.APP__APPLICATION__BASE_URL }} \
-          --set-env-vars=APP__BIGCOMMERCE__INSTALL_REDIRECT_URI=${{ secrets.APP__BIGCOMMERCE__INSTALL_REDIRECT_URI }} \
-          --set-env-vars=APP__DATABASE__REQUIRE_SSL=false \
-          --set-secrets=APP__DATABASE__SOCKET=APP__DATABASE__SOCKET:2 \
-          --set-secrets=APP__DATABASE__DATABASE_NAME=APP__DATABASE__DATABASE_NAME:1 \
-          --set-secrets=APP__DATABASE__PASSWORD=APP__DATABASE__PASSWORD:1 \
-          --set-secrets=APP__DATABASE__USERNAME=APP__DATABASE__USERNAME:1 \
-          --set-secrets=APP__BIGCOMMERCE__CLIENT_SECRET=APP__BIGCOMMERCE__CLIENT_SECRET:1 \
-          --set-secrets=APP__BIGCOMMERCE__CLIENT_ID=APP__BIGCOMMERCE__CLIENT_ID:1 \
-          --set-secrets=APP__APPLICATION__JWT_SECRET=APP__APPLICATION__JWT_SECRET:1 \
-          --set-secrets=APP__LIQ_PAY__PUBLIC_KEY=APP__LIQ_PAY__PUBLIC_KEY:2 \
-          --set-secrets=APP__LIQ_PAY__PRIVATE_KEY=APP__LIQ_PAY__PRIVATE_KEY:2
+          gcloud run services replace run-service.yaml
 
   coverage:
     name: coverage

--- a/otel/Dockerfile
+++ b/otel/Dockerfile
@@ -1,0 +1,3 @@
+FROM otel/opentelemetry-collector-contrib:0.87.0
+
+COPY otel/collector-config.yaml /etc/otelcol-contrib/config.yaml

--- a/otel/collector-config.yaml
+++ b/otel/collector-config.yaml
@@ -1,0 +1,47 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  batch:
+    # batch metrics before sending to reduce API usage
+    send_batch_max_size: 200
+    send_batch_size: 200
+    timeout: 5s
+
+  memory_limiter:
+    # drop metrics if memory usage gets too high
+    check_interval: 1s
+    limit_percentage: 65
+    spike_limit_percentage: 20
+
+  resourcedetection:
+    detectors: [env, gcp]
+    timeout: 2s
+    override: false
+
+exporters:
+  googlecloud:
+    log:
+      default_log_name: backend
+  googlemanagedprometheus:
+
+extensions:
+  health_check:
+
+service:
+  extensions: [health_check]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [resourcedetection]
+      exporters: [googlecloud]
+    logs:
+      receivers: [otlp]
+      processors: [resourcedetection]
+      exporters: [googlecloud]
+    metrics:
+      receivers: [otlp]
+      processors: [resourcedetection]
+      exporters: [googlemanagedprometheus]

--- a/run-service.yaml
+++ b/run-service.yaml
@@ -1,0 +1,103 @@
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: backend
+  annotations:
+    run.googleapis.com/ingress: all
+    run.googleapis.com/ingress-status: all
+spec:
+  template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/minScale: "1"
+        run.googleapis.com/cloudsql-instances: stand-with-ukraine-bc-app:us-central1:db
+        run.googleapis.com/execution-environment: gen2
+        autoscaling.knative.dev/maxScale: "5"
+    spec:
+      containerConcurrency: 1000
+      timeoutSeconds: 300
+      serviceAccountName: "%SERVICE_ACCOUNT%"
+      containers:
+        - name: app
+          image: "%APP_IMAGE%"
+          ports:
+            - name: http1
+              containerPort: "%APP__APPLICATION__PORT%"
+          env:
+            - name: OTEL_ENABLE
+              value: "true"
+            - name: RUST_LOG
+              value: "trace"
+            - name: APP__APPLICATION__PORT
+              value: "%APP__APPLICATION__PORT%"
+            - name: APP__APPLICATION__BASE_URL
+              value: "%APP__APPLICATION__BASE_URL%"
+            - name: APP__BIGCOMMERCE__INSTALL_REDIRECT_URI
+              value: "%APP__BIGCOMMERCE__INSTALL_REDIRECT_URI%"
+            - name: APP__DATABASE__REQUIRE_SSL
+              value: "false"
+            - name: APP__DATABASE__SOCKET
+              valueFrom:
+                secretKeyRef:
+                  key: "2"
+                  name: APP__DATABASE__SOCKET
+            - name: APP__DATABASE__DATABASE_NAME
+              valueFrom:
+                secretKeyRef:
+                  key: "1"
+                  name: APP__DATABASE__DATABASE_NAME
+            - name: APP__DATABASE__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: "1"
+                  name: APP__DATABASE__PASSWORD
+            - name: APP__DATABASE__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  key: "1"
+                  name: APP__DATABASE__USERNAME
+            - name: APP__BIGCOMMERCE__CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: "1"
+                  name: APP__BIGCOMMERCE__CLIENT_SECRET
+            - name: APP__BIGCOMMERCE__CLIENT_ID
+              valueFrom:
+                secretKeyRef:
+                  key: "1"
+                  name: APP__BIGCOMMERCE__CLIENT_ID
+            - name: APP__APPLICATION__JWT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  key: "1"
+                  name: APP__APPLICATION__JWT_SECRET
+            - name: APP__LIQ_PAY__PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "2"
+                  name: APP__LIQ_PAY__PUBLIC_KEY
+            - name: APP__LIQ_PAY__PRIVATE_KEY
+              valueFrom:
+                secretKeyRef:
+                  key: "2"
+                  name: APP__LIQ_PAY__PRIVATE_KEY
+          resources:
+            limits:
+              cpu: 750m
+              memory: 256Mi
+          startupProbe:
+            timeoutSeconds: 240
+            periodSeconds: 240
+            failureThreshold: 1
+            tcpSocket:
+              port: 8000
+        - name: otel-collector
+          image: "%OTEL_COLLECTOR_IMAGE%"
+          startupProbe:
+            httpGet:
+              path: /
+              port: 13133
+          resources:
+            limits:
+              cpu: 250m
+              memory: 256Mi


### PR DESCRIPTION
## What?

- add `otel-collector` sidecar container
- use `run-service.yaml` to store cloud run config

## Why?

- use same cloud run service & resources for open telemetry collector
- yaml file makes it easier to consolidate infrastructure changes

## Testing/Proof

N/A