### PR TITLE
feature: add error traces

### DIFF
--- a/apps/server/src/authentication.rs
+++ b/apps/server/src/authentication.rs
@@ -14,7 +14,6 @@ use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, 
 use secrecy::{ExposeSecret, Secret};
 use serde::{Deserialize, Serialize};
 use time::{Duration, OffsetDateTime};
-use tracing::trace;
 
 use crate::state::SharedState;
 
@@ -57,6 +56,7 @@ impl IntoResponse for Error {
     }
 }
 
+#[tracing::instrument(name = "create jwt token", skip(secret))]
 pub fn create_jwt(
     store_hash: &str,
     secret: &Secret<String>,
@@ -82,8 +82,6 @@ pub fn decode_token(token: &str, secret: &Secret<String>) -> Result<AuthClaims, 
     let mut validation = Validation::new(Algorithm::HS512);
     validation.validate_aud = false;
     let decoded = decode::<AuthClaims>(token, &key, &validation).map_err(Error::InvalidToken)?;
-
-    trace!(?decoded, "token decoded");
 
     Ok(decoded.claims)
 }

--- a/apps/server/src/authentication.rs
+++ b/apps/server/src/authentication.rs
@@ -48,6 +48,7 @@ where
 }
 
 impl IntoResponse for Error {
+    #[tracing::instrument(name = "authentication error")]
     fn into_response(self) -> Response {
         match self {
             Self::InvalidToken(_) | Self::NoToken => (StatusCode::BAD_REQUEST, "Invalid token"),

--- a/apps/server/src/data.rs
+++ b/apps/server/src/data.rs
@@ -8,7 +8,7 @@ use uuid::Uuid;
 
 use crate::bigcommerce::{script::Script, store::APIToken};
 
-#[tracing::instrument(name = "Write store credentials to database", skip(store, pool))]
+#[tracing::instrument(name = "write store credentials to database", skip(store, pool))]
 pub async fn write_store_credentials(store: &APIToken, pool: &PgPool) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
@@ -27,7 +27,7 @@ pub async fn write_store_credentials(store: &APIToken, pool: &PgPool) -> Result<
     Ok(())
 }
 
-#[tracing::instrument(name = "Read store credentials from database", skip(store_hash, pool))]
+#[tracing::instrument(name = "read store credentials from database", skip(store_hash, pool))]
 pub async fn read_store_credentials(
     store_hash: &str,
     pool: &PgPool,
@@ -48,7 +48,7 @@ pub async fn read_store_credentials(
 }
 
 #[tracing::instrument(
-    name = "Write store is uninstalled in database",
+    name = "write store is uninstalled in database",
     skip(store_hash, pool)
 )]
 pub async fn write_store_as_uninstalled(
@@ -70,7 +70,7 @@ pub async fn write_store_as_uninstalled(
 }
 
 #[tracing::instrument(
-    name = "Write store published status in database",
+    name = "write store published status in database",
     skip(store_hash, pool)
 )]
 pub async fn write_store_published(
@@ -93,7 +93,7 @@ pub async fn write_store_published(
     Ok(())
 }
 
-#[tracing::instrument(name = "Write unpublish feedback to database", skip(store_hash, pool))]
+#[tracing::instrument(name = "write unpublish feedback to database", skip(store_hash, pool))]
 pub async fn write_unpublish_feedback(
     store_hash: &str,
     reason: &str,
@@ -123,7 +123,7 @@ pub struct StoreStatus {
 }
 
 #[tracing::instrument(
-    name = "Read store published status from database",
+    name = "read store published status from database",
     skip(store_hash, pool)
 )]
 pub async fn read_store_published(
@@ -175,7 +175,7 @@ impl WidgetConfiguration {
 }
 
 #[tracing::instrument(
-    name = "Write widget configuration to database",
+    name = "write widget configuration to database",
     skip(store_hash, db_pool)
 )]
 pub async fn write_widget_configuration(
@@ -204,7 +204,7 @@ pub async fn write_widget_configuration(
 }
 
 #[tracing::instrument(
-    name = "Read widget configuration from database",
+    name = "read widget configuration from database",
     skip(store_hash, db_pool)
 )]
 pub async fn read_widget_configuration(
@@ -255,7 +255,7 @@ pub struct CharityEvent {
     event: CharityEventType,
 }
 
-#[tracing::instrument(name = "Write charity visit event to database", skip(db_pool))]
+#[tracing::instrument(name = "write charity visit event to database", skip(db_pool))]
 pub async fn write_charity_visited_event(
     event: &CharityEvent,
     db_pool: &PgPool,
@@ -328,7 +328,7 @@ pub fn store_hash_field_from_str(store_hash: &str) -> Option<&str> {
     }
 }
 
-#[tracing::instrument(name = "Write widget event to database", skip(db_pool))]
+#[tracing::instrument(name = "write widget event to database", skip(db_pool))]
 pub async fn write_widget_event(event: &WidgetEvent, db_pool: &PgPool) -> Result<(), sqlx::Error> {
     sqlx::query!(
         r#"
@@ -352,7 +352,7 @@ pub struct FeedbackForm {
     message: String,
 }
 
-#[tracing::instrument(name = "Write feedback to database", skip(db_pool))]
+#[tracing::instrument(name = "write feedback to database", skip(db_pool))]
 pub async fn write_general_feedback(
     data: &FeedbackForm,
     db_pool: &PgPool,
@@ -396,7 +396,7 @@ pub struct UniversalConfiguratorEvent {
     event_type: UniversalConfiguratorEventType,
 }
 
-#[tracing::instrument(name = "Write universal widget event to database", skip(db_pool))]
+#[tracing::instrument(name = "write universal widget event to database", skip(db_pool))]
 pub async fn write_universal_widget_event(
     data: &UniversalConfiguratorEvent,
     db_pool: &PgPool,

--- a/apps/server/src/liq_pay.rs
+++ b/apps/server/src/liq_pay.rs
@@ -90,7 +90,7 @@ impl HttpAPI {
         }
     }
 
-    #[tracing::instrument(name = "Generate payload", skip(self))]
+    #[tracing::instrument(name = "generate request payload", skip(self))]
     pub fn generate_request_payload(
         &self,
         query: InputQuery,
@@ -118,7 +118,7 @@ impl HttpAPI {
         }
     }
 
-    #[tracing::instrument(name = "Generate LiqPay link", skip(self))]
+    #[tracing::instrument(name = "generate link", skip(self))]
     pub fn link(&self, request: CheckoutRequest) -> String {
         let data = serde_json::to_string(&request).unwrap();
         let data = encoder.encode(data);

--- a/apps/server/src/routes/bigcommerce.rs
+++ b/apps/server/src/routes/bigcommerce.rs
@@ -34,6 +34,7 @@ enum InstallError {
 }
 
 impl IntoResponse for InstallError {
+    #[tracing::instrument(name = "install error")]
     fn into_response(self) -> Response {
         match self {
             Self::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
@@ -107,6 +108,7 @@ enum LoadError {
 }
 
 impl IntoResponse for LoadError {
+    #[tracing::instrument(name = "load error")]
     fn into_response(self) -> Response {
         match self {
             Self::NotStoreOwnerError | Self::InvalidCredentials(_) => StatusCode::UNAUTHORIZED,

--- a/apps/server/src/routes/bigcommerce.rs
+++ b/apps/server/src/routes/bigcommerce.rs
@@ -43,7 +43,7 @@ impl IntoResponse for InstallError {
 }
 
 #[tracing::instrument(
-    name = "Process install request",
+    name = "process install request",
     skip(query, bigcommerce_client, db_pool, jwt_secret, base_url),
     fields(context=tracing::field::Empty, user_email=tracing::field::Empty)
 )]
@@ -119,7 +119,7 @@ impl IntoResponse for LoadError {
 }
 
 #[tracing::instrument(
-    name = "Process load request",
+    name = "load request",
     skip(query, bigcommerce_client, base_url, jwt_secret)
 )]
 async fn load(
@@ -146,10 +146,7 @@ async fn load(
     Ok(Redirect::to(&generate_dashboard_url(&base_url, &jwt, store_hash)).into_response())
 }
 
-#[tracing::instrument(
-    name = "Process uninstall request",
-    skip(query, bigcommerce_client, db_pool)
-)]
+#[tracing::instrument(name = "uninstall request", skip(query, bigcommerce_client, db_pool))]
 async fn uninstall(
     Query(query): Query<LoadQuery>,
     State(AppState {

--- a/apps/server/src/routes/pay.rs
+++ b/apps/server/src/routes/pay.rs
@@ -9,7 +9,7 @@ pub fn router() -> Router<SharedState> {
     Router::new().route("/", get(pay))
 }
 
-#[tracing::instrument(name = "Process pay request", skip(query, liq_pay_client))]
+#[tracing::instrument(name = "pay request", skip(query, liq_pay_client))]
 async fn pay(
     Query(query): Query<InputQuery>,
     State(AppState { liq_pay_client, .. }): State<AppState>,

--- a/apps/server/src/routes/widget.rs
+++ b/apps/server/src/routes/widget.rs
@@ -60,7 +60,7 @@ impl IntoResponse for ConfigurationError {
     }
 }
 
-#[tracing::instrument(name = "Save widget configuration", skip(auth, db_pool))]
+#[tracing::instrument(name = "save widget configuration", skip(auth, db_pool))]
 async fn save_widget_configuration(
     auth: AuthClaims,
     State(AppState { db_pool, .. }): State<AppState>,
@@ -75,7 +75,7 @@ async fn save_widget_configuration(
     Ok(StatusCode::OK.into_response())
 }
 
-#[tracing::instrument(name = "Get widget configuration", skip(auth, db_pool))]
+#[tracing::instrument(name = "get widget configuration", skip(auth, db_pool))]
 async fn get_widget_configuration(
     auth: AuthClaims,
     State(AppState { db_pool, .. }): State<AppState>,
@@ -106,7 +106,7 @@ impl IntoResponse for PublishError {
 }
 
 #[tracing::instrument(
-    name = "Publish the widget",
+    name = "publish widget",
     skip(auth, db_pool, base_url, bigcommerce_client)
 )]
 async fn publish_widget(
@@ -161,7 +161,7 @@ struct Feedback {
 }
 
 #[tracing::instrument(
-    name = "Remove widget",
+    name = "remove widget",
     skip(auth, db_pool, bigcommerce_client, feedback)
 )]
 async fn remove_widget(
@@ -201,7 +201,7 @@ async fn remove_widget(
     Ok(StatusCode::OK.into_response())
 }
 
-#[tracing::instrument(name = "Preview widget", skip(auth, db_pool, bigcommerce_client))]
+#[tracing::instrument(name = "preview widget", skip(auth, db_pool, bigcommerce_client))]
 async fn preview_widget(
     auth: AuthClaims,
     State(AppState {
@@ -226,7 +226,7 @@ async fn preview_widget(
     Ok(Json(store_information).into_response())
 }
 
-#[tracing::instrument(name = "Get widget status", skip(auth, db_pool))]
+#[tracing::instrument(name = "get widget status", skip(auth, db_pool))]
 async fn get_published_status(
     auth: AuthClaims,
     State(AppState { db_pool, .. }): State<AppState>,
@@ -241,49 +241,49 @@ async fn get_published_status(
     Ok(Json(store_status).into_response())
 }
 
-#[tracing::instrument(name = "Log charity event", skip(db_pool))]
+#[tracing::instrument(name = "log charity event", skip(db_pool))]
 async fn log_charity_event(
     Query(event): Query<CharityEvent>,
     State(AppState { db_pool, .. }): State<AppState>,
 ) -> Response {
     if let Err(error) = write_charity_visited_event(&event, &db_pool).await {
-        tracing::warn!("Error while saving event {}", error);
+        tracing::warn!("error while saving event {}", error);
     };
 
     StatusCode::OK.into_response()
 }
 
-#[tracing::instrument(name = "Save feedback form", skip(db_pool))]
+#[tracing::instrument(name = "save feedback form", skip(db_pool))]
 async fn submit_general_feedback(
     Query(event): Query<FeedbackForm>,
     State(AppState { db_pool, .. }): State<AppState>,
 ) -> Response {
     if let Err(error) = write_general_feedback(&event, &db_pool).await {
-        tracing::warn!("Error while saving event {}", error);
+        tracing::warn!("error while saving event {}", error);
     };
 
     StatusCode::OK.into_response()
 }
 
-#[tracing::instrument(name = "Save universal configurator event", skip(db_pool))]
+#[tracing::instrument(name = "save universal configurator event", skip(db_pool))]
 async fn submit_universal_configurator_event(
     Query(event): Query<UniversalConfiguratorEvent>,
     State(AppState { db_pool, .. }): State<AppState>,
 ) -> Response {
     if let Err(error) = write_universal_widget_event(&event, &db_pool).await {
-        tracing::warn!("Error while saving event {}", error);
+        tracing::warn!("error while saving event {}", error);
     };
 
     StatusCode::OK.into_response()
 }
 
-#[tracing::instrument(name = "Log widget event", skip(db_pool))]
+#[tracing::instrument(name = "log widget event", skip(db_pool))]
 async fn log_widget_event(
     Query(event): Query<WidgetEvent>,
     State(AppState { db_pool, .. }): State<AppState>,
 ) -> Response {
     if let Err(error) = write_widget_event(&event, &db_pool).await {
-        tracing::warn!("Error while saving event {}", error);
+        tracing::warn!("error while saving event {}", error);
     };
 
     StatusCode::OK.into_response()

--- a/apps/server/src/routes/widget.rs
+++ b/apps/server/src/routes/widget.rs
@@ -52,6 +52,7 @@ enum ConfigurationError {
 }
 
 impl IntoResponse for ConfigurationError {
+    #[tracing::instrument(name = "configuration error")]
     fn into_response(self) -> axum::response::Response {
         match self {
             Self::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR.into_response(),
@@ -95,6 +96,7 @@ enum PublishError {
 }
 
 impl IntoResponse for PublishError {
+    #[tracing::instrument(name = "publish error")]
     fn into_response(self) -> Response {
         match self {
             Self::UnexpectedError(_) => StatusCode::INTERNAL_SERVER_ERROR,

--- a/apps/server/tests/e2e/helpers.rs
+++ b/apps/server/tests/e2e/helpers.rs
@@ -29,6 +29,7 @@ pub struct TestApp {
     pub jwt_secret: Secret<String>,
     pub base_url: String,
     pub bc_secret: Secret<String>,
+    pub bc_client_id: String,
     pub bc_redirect_uri: String,
 
     pub test_client: Client,
@@ -67,6 +68,7 @@ pub async fn spawn_app() -> TestApp {
         db_pool: get_connection_pool(&configuration.database),
         jwt_secret: configuration.application.jwt_secret,
         bc_secret: configuration.bigcommerce.client_secret,
+        bc_client_id: configuration.bigcommerce.client_id,
         bc_redirect_uri: configuration.bigcommerce.install_redirect_uri,
         base_url: configuration.application.base_url,
         test_client: reqwest::Client::new(),
@@ -119,8 +121,11 @@ impl TestApp {
         let expiration = now + Duration::minutes(30);
         let claims = serde_json::json!( {
             "iss": "bc",
+            "aud": self.bc_client_id,
             "iat": now.unix_timestamp(),
+            "nbf": now.unix_timestamp() - 5,
             "exp": expiration.unix_timestamp(),
+            "jti": uuid::Uuid::new_v4().to_string(),
             "sub": sub,
             "user": user,
             "owner": owner,


### PR DESCRIPTION
## What?

- add tracing for every error response
- standardize the formatting of tracing event names
- improve bc load jwt token test

## Why?

- have information on errors in trace explorer
- make sure `jsonwebtoken` library changes don't unexpectedly break app load like it did with `aud` validation.

## Testing/Proof

<img width="2032" alt="Screenshot 2024-03-04 at 9 58 41 AM" src="https://github.com/bigcommerce/stand-with-ukraine-backend/assets/95306190/928cbf24-f2e5-4abb-bf89-e8176f8f5429">

